### PR TITLE
비밀번호 변경 버튼 문구 수정 #39

### DIFF
--- a/src/components/SettingsList.jsx
+++ b/src/components/SettingsList.jsx
@@ -106,7 +106,7 @@ export default function SettingsList() {
                                 closeModal();
                             }}
                         >
-                            비밀번호 변경
+                            저장
                         </button>
                     </div>
                 </ModalLayout>


### PR DESCRIPTION
![스크린샷 2025-05-05 185727](https://github.com/user-attachments/assets/b6c0559e-8a04-4dd1-8d7d-14e6b3f4f83c)

"비밀번호 변경" -> "저장" 으로 문구 변경 완료